### PR TITLE
force send on maximum byte size

### DIFF
--- a/loki_logger_handler/loki_logger_handler.py
+++ b/loki_logger_handler/loki_logger_handler.py
@@ -205,7 +205,7 @@ class LokiLoggerHandler(logging.Handler):
         log_line = LogLine(labels, log_record)
         log_size = log_line.size()
         self.buffer.put(log_line)
-        self.current_stream_size += log_size
+        self._current_stream_size += log_size
 
         if (
             self.max_stream_size > 0


### PR DESCRIPTION
First idea for #27 

This checks for bytesize of logline when adding it to the buffer. Inside flush it is check multiple times (every 100ms) if a force_send is necessary.