### PR TITLE
Exclude test packages from distribution in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ setup(
     long_description=long_description,
     long_description_content_type="text/markdown",
     url="https://github.com/xente/loki-logger-handler",
-    packages=find_packages(),
+    packages=find_packages(exclude=["tests*", "tests.*"]),
     classifiers=[
         "Development Status :: 5 - Production/Stable",
         "Intended Audience :: Developers",


### PR DESCRIPTION
This pull request includes a change to the `setup.py` file to improve the packaging configuration. The change excludes test directories from the list of packages to be included in the distribution.

* [`setup.py`](diffhunk://#diff-60f61ab7a8d1910d86d9fda2261620314edcae5894d5aaa236b821c7256badd7L15-R15): Modified the `find_packages` function to exclude directories matching "tests*" and "tests.*".