### PR TITLE
add requests timeout value - prevent infinitely hanging requests

### DIFF
--- a/loki_logger_handler/loki_logger_handler.py
+++ b/loki_logger_handler/loki_logger_handler.py
@@ -34,8 +34,8 @@ class LokiLoggerHandler(logging.Handler):
         enable_self_errors=False,
         enable_structured_loki_metadata=False,
         loki_metadata=None,
-        loki_metadata_keys=None
-
+        loki_metadata_keys=None,
+        requests_timeout=None,
     ):
         """
         Initialize the LokiLoggerHandler object.
@@ -54,6 +54,7 @@ class LokiLoggerHandler(logging.Handler):
             enable_structured_loki_metadata (bool, optional):  Whether to include structured loki_metadata in the logs. Defaults to False. Only supported for Loki 3.0 and above
             loki_metadata (dict, optional): Default loki_metadata values. Defaults to None. Only supported for Loki 3.0 and above
             loki_metadata_keys (arrray, optional): Specific log record keys to extract as loki_metadata. Only supported for Loki 3.0 and above
+            requests_timeout (int or tuple, optional): Timeout for requests to the Loki server. Defaults to None, which is the default timeout of the requests library.
         """
         super(LokiLoggerHandler, self).__init__()
 
@@ -72,7 +73,7 @@ class LokiLoggerHandler(logging.Handler):
             self.debug_logger.addHandler(console_handler)
 
         self.request = LokiRequest(
-            url=url, compressed=compressed, auth=auth, additional_headers=additional_headers or {}
+            url=url, compressed=compressed, auth=auth, additional_headers=additional_headers or {}, timeout=requests_timeout
         )
 
         self.buffer = queue.Queue()

--- a/loki_logger_handler/loki_request.py
+++ b/loki_logger_handler/loki_request.py
@@ -15,7 +15,7 @@ class LokiRequest:
         session (requests.Session): The session used for making HTTP requests.
     """
 
-    def __init__(self, url, compressed=False, auth=None, additional_headers=None):
+    def __init__(self, url, compressed=False, auth=None, additional_headers=None, timeout=None):
         """
         Initialize the LokiRequest object with the server URL, compression option, and additional headers.
 
@@ -32,6 +32,7 @@ class LokiRequest:
         self.headers = additional_headers if additional_headers is not None else {}
         self.headers["Content-Type"] = "application/json"
         self.session = requests.Session()
+        self.timeout = timeout
 
     def send(self, data):
         """
@@ -49,7 +50,7 @@ class LokiRequest:
                 self.headers["Content-Encoding"] = "gzip"
                 data = gzip.compress(data.encode("utf-8"))
             
-            response = self.session.post(self.url, data=data, auth=self.auth, headers=self.headers)
+            response = self.session.post(self.url, data=data, auth=self.auth, headers=self.headers, timeout=self.timeout)
             response.raise_for_status()
             
         except requests.RequestException as e:


### PR DESCRIPTION
This MR allows users to specify a timeout value for requests. An excerpt from the creators of the request library: 
"Nearly all production code should use this parameter in nearly all requests. Failure to do so can cause your program to hang indefinitely."

https://docs.python-requests.org/en/latest/user/quickstart/#timeouts

Might be worth setting a default value for this.